### PR TITLE
Added ManifoldCordova plugin as npm dependencies

### DIFF
--- a/lib/projectBuilder.js
+++ b/lib/projectBuilder.js
@@ -1,5 +1,5 @@
 // ID or URL of the Hosted Web App plugin - THIS SETTING WILL NEED TO BE UPDATED IF THE PLUGIN IS RELOCATED
-var pluginIdOrUrl = 'https://github.com/manifoldjs/ManifoldCordova.git';
+var pluginIdOrUrl = require('ManifoldCordova'); //'https://github.com/manifoldjs/ManifoldCordova.git';
 
 var manifestTools = require('./manifestTools'),
     path = require('path'),
@@ -23,7 +23,7 @@ var createApps = function (w3cManifestInfo, rootDir, platforms, build, callback)
       return callback(err);
     }
 
-    // process all requested platforms    
+    // process all requested platforms
     var pendingTasks = [];
     var cordovaPlatforms = [];
     platforms.forEach(function (el) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manifoldjs",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Node.js tool for App Generation",
   "author": {
     "name": "TBD",
@@ -18,6 +18,7 @@
     "iOS"
   ],
   "dependencies": {
+    "ManifoldCordova": "git://github.com/manifoldjs/ManifoldCordova.git",
     "cheerio": "^0.18.0",
     "cordova": "^4.3.0",
     "loglevel": "^1.2.0",


### PR DESCRIPTION
This should workaround the #9 issue until we publish the ManifoldCordova plugin in the Cordova plugin index.