### PR TITLE
Start url normalization

### DIFF
--- a/lib/manifestTools.js
+++ b/lib/manifestTools.js
@@ -63,51 +63,6 @@ function convertTo(manifestInfo, outputFormat, callback) {
   });
 }
 
-function getW3cManifest(siteUrl, manifestLocation, callback) {
-    var parsedSiteUrl = url.parse(siteUrl);
-
-    function manifestRetrieved(err, manifestInfo) {
-        if (err) {
-            return callback(err, manifestInfo);
-        }
-
-        if (manifestInfo.format !== c.BASE_MANIFEST_FORMAT) {
-            return callback(new Error("The manifest found is not a W3C manifest."), manifestInfo);
-        }
-
-        var parsedManifestStartUrl = url.parse(manifestInfo.content.start_url);
-        if (parsedManifestStartUrl.hostname && parsedSiteUrl.hostname !== parsedManifestStartUrl.hostname) {
-            return callback(new Error("The domain of the hosted site (" + parsedSiteUrl.hostname + ") does not match the domain of the manifest's start_url parameter (" + parsedManifestStartUrl.hostname + ")"), manifestInfo);
-        }
-
-        // make sure the manifest's start_url is an absolute URL
-        manifestInfo.content.start_url = url.resolve(siteUrl, manifestInfo.content.start_url);
-
-        return callback(undefined, manifestInfo);
-    }
-
-    if (!parsedSiteUrl.hostname) {
-        return callback(new Error("The site URL is not a valid URL."));
-    }
-
-    if (manifestLocation) {
-        var parsedManifestUrl = url.parse(manifestLocation);
-        if (parsedManifestUrl && parsedManifestUrl.host) {
-            // download manifest from remote location
-            log.info('Downloading manifest from ' + manifestLocation + '...');
-            downloadManifestFromUrl(manifestLocation, manifestRetrieved);
-        } else {
-            // read local manifest file
-            log.info('Reading manifest file ' + manifestLocation + '...');
-            getManifestFromFile(manifestLocation, manifestRetrieved);
-        }
-    } else {
-        // scan a site to retrieve its manifest
-        log.info('Scanning ' + siteUrl + ' for manifest...');
-        getManifestFromSite(siteUrl, manifestRetrieved);
-    }
-}
-
 function getManifestUrlFromSite(siteUrl, callback) {
   request({
     uri: siteUrl
@@ -279,15 +234,31 @@ function validateManifest(manifestInfo, targetPlatforms, callback) {
       });
 }
 
-module.exports = {
-  getW3cManifest: getW3cManifest,
+function validateAndNormalizeStartUrl(siteUrl, manifestInfo, callback) {
+  if (manifestInfo.format !== c.BASE_MANIFEST_FORMAT) {
+    return callback(new Error("The manifest found is not a W3C manifest."), manifestInfo);
+  }
 
+  var parsedManifestStartUrl = url.parse(manifestInfo.content.start_url);
+  if (parsedManifestStartUrl.hostname && parsedSiteUrl.hostname !== parsedManifestStartUrl.hostname) {
+    return callback(new Error("The domain of the hosted site (" + parsedSiteUrl.hostname + ") does not match the domain of the manifest's start_url parameter (" + parsedManifestStartUrl.hostname + ")"), manifestInfo);
+  }
+
+  // make sure the manifest's start_url is an absolute URL
+  manifestInfo.content.start_url = url.resolve(siteUrl, manifestInfo.content.start_url);
+
+  return callback(undefined, manifestInfo);
+}
+
+module.exports = {
   getManifestFromSite: getManifestFromSite,
   getManifestFromFile: getManifestFromFile,
   writeToFile: writeToFile,
 
   getManifestUrlFromSite: getManifestUrlFromSite,
   downloadManifestFromUrl: downloadManifestFromUrl,
+
+  validateAndNormalizeStartUrl: validateAndNormalizeStartUrl,
 
   convertTo: convertTo,
 

--- a/lib/projectBuilder.js
+++ b/lib/projectBuilder.js
@@ -9,9 +9,25 @@ var manifestTools = require('./manifestTools'),
     log = require('loglevel'),
     downloader = require('./projectBuilder/downloader'),
     Q = require('q'),
+    c = require('./manifestTools/constants'),
     mkdirp = require('mkdirp');
 
+function validateManifest(manifestInfo) {
+  if (manifestInfo.format !== c.BASE_MANIFEST_FORMAT) {
+    return new Error("The manifest passed as parameter is not a W3C manifest.");
+  }
+
+  var parsedManifestStartUrl = url.parse(manifestInfo.content.start_url);
+  if (!parsedManifestStartUrl.hostname) {
+    return new Error("The manifest's start_url parameter (" + parsedManifestStartUrl.hostname + ") is not a full url.");
+  }
+}
+
 var createApps = function (w3cManifestInfo, rootDir, platforms, build, callback) {
+  var err = validateManifest(w3cManifestInfo);
+  if (err) {
+    return callback(err);
+  }
 
   // determine the path where the Cordova app will be created
   var appName = w3cManifestInfo.content.short_name;
@@ -23,7 +39,7 @@ var createApps = function (w3cManifestInfo, rootDir, platforms, build, callback)
       return callback(err);
     }
 
-    // process all requested platforms    
+    // process all requested platforms
     var pendingTasks = [];
     var cordovaPlatforms = [];
     platforms.forEach(function (el) {
@@ -164,6 +180,11 @@ var createFirefoxApp = function (w3cManifestInfo, generatedAppDir, build) {
 };
 
 var createCordovaApp = function (w3cManifestInfo, generatedAppDir, platforms, build) {
+  var err = validateManifest(w3cManifestInfo);
+  if (err) {
+    return callback(err);
+  }
+
   log.info('Generating the Cordova application...');
 
   var task = Q.defer();

--- a/manifoldjs.js
+++ b/manifoldjs.js
@@ -45,6 +45,39 @@ function checkParameters(argv) {
   }
 }
 
+function getW3cManifest(siteUrl, manifestLocation, callback) {
+  function resolveStartURL(err, manifestInfo) {
+    if (err) {
+      return callback(err, manifestInfo);
+    }
+
+    return manifestTools.validateAndNormalizeStartUrl(siteUrl, manifestInfo, callback);
+  }
+
+  var parsedSiteUrl = url.parse(siteUrl);
+
+  if (!parsedSiteUrl.hostname) {
+    return callback(new Error("The site URL is not a valid URL."));
+  }
+
+  if (manifestLocation) {
+    var parsedManifestUrl = url.parse(manifestLocation);
+    if (parsedManifestUrl && parsedManifestUrl.host) {
+      // download manifest from remote location
+      log.info('Downloading manifest from ' + manifestLocation + '...');
+      manifestTools.downloadManifestFromUrl(manifestLocation, resolveStartURL);
+    } else {
+      // read local manifest file
+      log.info('Reading manifest file ' + manifestLocation + '...');
+      manifestTools.getManifestFromFile(manifestLocation, resolveStartURL);
+    }
+  } else {
+    // scan a site to retrieve its manifest
+    log.info('Scanning ' + siteUrl + ' for manifest...');
+    manifestTools.getManifestFromSite(siteUrl, resolveStartURL);
+  }
+}
+
 var parameters = require('optimist')
                 .usage('Usage: manifoldjs <website-url> [-d <app-directory>] [-s <short-name>]\n' +
                        '                                [-p <platforms>] [-l <log-level>]\n' +
@@ -88,7 +121,7 @@ if (parameters._[0].toLowerCase() === 'run') {
       log.error('ERROR: ' + err.message);
       return;
     }
-    
+
     log.info('The Visual Studio project was opened successfully!');
   });
 
@@ -98,7 +131,7 @@ if (parameters._[0].toLowerCase() === 'run') {
   var siteUrl = parameters._[0];
   var rootDir = parameters.directory ? parameters.directory : process.cwd();
   var platforms = parameters.platforms.split(/[\s,]+/);
-  manifestTools.getW3cManifest(siteUrl, parameters.manifest, function (err, manifestInfo) {
+  getW3cManifest(siteUrl, parameters.manifest, function (err, manifestInfo) {
     if (err) {
       log.error('ERROR: ' + err.message);
       return;


### PR DESCRIPTION
- Removed getW3cManifest from manifest tools
- Added validateAndNormalizeStartUrl method to manifest tools
- Added validation in the project builder to check if the start_url is a full url