### PR TITLE
Fix link CSS query

### DIFF
--- a/lib/manifestTools.js
+++ b/lib/manifestTools.js
@@ -72,7 +72,7 @@ function getManifestUrlFromSite(siteUrl, callback) {
     }
 
     var $ = cheerio.load(body);
-    var manifestUrl = $('link[rel=manifest]').attr('href');
+    var manifestUrl = $('link[rel~="manifest"]').attr('href');
     if (manifestUrl) {
       var parsedManifestUrl = url.parse(manifestUrl);
       if (!parsedManifestUrl.host) {


### PR DESCRIPTION
The spec says find the first `<link>` that contains a token `manifest` (so, `link rel="foo bar manifest baz") is valid, so instace ;)