### PR TITLE
Fixes #35: line endings for mac/unix systems

### DIFF
--- a/manifoldjs.js
+++ b/manifoldjs.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+
 var validations = require('./lib/common/validations'),
     manifestTools = require('./lib/manifestTools'),
     projectBuilder = require('./lib/projectBuilder'),


### PR DESCRIPTION
**Install and get the location**

```
05/04/15 @ 1:27PM - kevincobain2000@Mac Air ~/Downloads npm install -g manifoldjs
npm WARN engine npm@1.3.4: wanted: {"node":">=0.6","npm":"1"} (current: {"node":"0.10.36","npm":"2.5.0"})
/usr/local/bin/manifoldjs -> /usr/local/lib/node_modules/manifoldjs/manifoldjs.js
..
...
..
```

The Issue #35

```
05/04/15 @ 1:28PM - kevincobain2000@Mac Air ~/Downloads rm -rf native;manifoldjs http://localhost:8080/ -d native  -p ios -b
env: node\r: No such file or directory
```

Work Log

```
05/04/15 @ 1:29PM - kevincobain2000@Mac Air ~/Downloads ls -la /usr/local/bin/manifoldjs
lrwxr-xr-x  1 kevincobain2000  admin  44 May  4 13:28 /usr/local/bin/manifoldjs -> ../lib/node_modules/manifoldjs/manifoldjs.js
```


```
05/04/15 @ 1:30PM - kevincobain2000@Mac Air ~/Downloads ls -l /usr/local/lib/node_modules/manifoldjs/manifoldjs.js
-rwxr-xr-x  1 kevincobain2000  wheel  6018 Apr 30 00:22 /usr/local/lib/node_modules/manifoldjs/manifoldjs.js
05/04/15 @ 1:31PM - kevincobain2000@Mac Air ~/Downloads wc -l /usr/local/lib/node_modules/manifoldjs/manifoldjs.js
     171 /usr/local/lib/node_modules/manifoldjs/manifoldjs.js
```


```
 05/04/15 @ 1:31PM - kevincobain2000@Mac Air ~/Downloads cat /usr/local/lib/node_modules/manifoldjs/manifoldjs.js |col -b > temp; cp temp /usr/local/lib/node_modules/manifoldjs/manifoldjs.js
 05/04/15 @ 1:32PM - kevincobain2000@Mac Air ~/Downloads wc -l /usr/local/lib/node_modules/manifoldjs/manifoldjs.js
     171 /usr/local/lib/node_modules/manifoldjs/manifoldjs.js
```


----

**This Pull Request**

```
05/04/15 @ 1:38PM - kevincobain2000@Mac Air ~/Downloads cp /usr/local/lib/node_modules/manifoldjs/manifoldjs.js ManifoldJS/manifoldjs.js
```


**All Good**

```
05/04/15 @ 1:32PM - kevincobain2000@Mac Air ~/Downloads rm -rf native;manifoldjs http://localhost:8080/ -d native  -p ios -b
WARNING: No manifest found. A new manifest will be created.Validation warning (ios): An app icon of the following sizes is required: 76x76, 120x120, 152x152 and 180x180Validation warning (ios): An 1024x1024 app icon for the App Store is required
Validation warning (ios): A launch image of the following sizes is required: 750x1334, 1334x750, 1242x2208, 2208x1242, 640x1136, 640x960, 1536x2048, 2048x1536, 768x1024 and 1024x768
ERROR: Failed to copy the manifest to the app folder.
WARNING: The Cordova project could not be created successfully.
WARNING: One or more errors occurred when generating the application.
```

**After Merge**

Actual diff is here (https://github.com/manifoldjs/ManifoldJS/pull/36/files#diff-b3753cf36ac588be23849590db6a56bcR1), it is invisible but it is a replacement of new line character \r for unix/mac systems. New line chars don't create a diff so I had to add a new line here (https://github.com/manifoldjs/ManifoldJS/pull/36/files#diff-b3753cf36ac588be23849590db6a56bcR3) to generate atleast some diff. After Merging this you can get rid of that new line or leave it as it is.