### PR TITLE
Fixed wildcard issue in Windows hosted web app ACURs

### DIFF
--- a/lib/manifestTools/assets/windows10/appxmanifest-template.xml
+++ b/lib/manifestTools/assets/windows10/appxmanifest-template.xml
@@ -13,7 +13,7 @@ IgnorableNamespaces="uap mp">
 	</Properties> 
 
 	<Dependencies> 
-		<TargetPlatform Name="Windows.Universal" MinVersion="0.0.0.0" MaxVersionTested="10.0.0.0" /> 
+		<TargetPlatform Name="Windows.Universal" MinVersion="10.0.10030.0" MaxVersionTested="10.0.10030.0" /> 
 	</Dependencies> 
 
 	<Resources>

--- a/lib/platformUtils/windows10Utils.js
+++ b/lib/platformUtils/windows10Utils.js
@@ -22,25 +22,33 @@ function replaceManifestValues(w3cManifest, content) {
   // Update access rules
   var indentationChars = '\r\n\t\t\t\t';
 
-  // Add base access rule based on the start_url and the scope
-  var baseUrlPattern = w3cManifest.start_url;
+  // Set the base access rule using the start_url's base url
+  var baseUrlPattern = url.resolve(w3cManifest.start_url, '/');
   if (w3cManifest.scope && w3cManifest.scope.length) {
-      baseUrlPattern = url.resolve(baseUrlPattern, w3cManifest.scope);
+    // If the scope is defined, the base access rule is defined by the scope
+    baseUrlPattern = url.resolve(baseUrlPattern, w3cManifest.scope);
   }
   
-  baseUrlPattern = url.resolve(baseUrlPattern, '*');
+  // If the base access rule ends with '/*', remove the '*'.
+  if (baseUrlPattern.indexOf('/*', baseUrlPattern.length - 2) !== -1) {
+    baseUrlPattern = baseUrlPattern.substring(0, baseUrlPattern.length - 1);
+  }
 
   var applicationContentUriRules = '<uap:Rule Type="include" Match="' + baseUrlPattern + '" />';
 
-  // add additional access rules
-  if (w3cManifest.mjs_access_whitelist && w3cManifest.mjs_access_whitelist instanceof Array) {
-    var baseUrl = baseUrlPattern.substring(0, baseUrlPattern.length - 1);
-    
+  // Add additional access rules
+  if (w3cManifest.mjs_access_whitelist && w3cManifest.mjs_access_whitelist instanceof Array) {    
     for (var j = 0; j < w3cManifest.mjs_access_whitelist.length; j++) {
-      var accessUrl = w3cManifest.mjs_access_whitelist[j];
-      if (accessUrl.url !== '*') {
-        if (accessUrl.url.indexOf(baseUrl) !== 0) { // To avoid duplicates, add the rule only if it does not have the base URL as a prefix
-          applicationContentUriRules += indentationChars + '<uap:Rule Type="include" Match="' + accessUrl.url + '" />';
+      var accessUrl = w3cManifest.mjs_access_whitelist[j].url;
+      // Ignore the '*' rule 
+      if (accessUrl !== '*') {        
+        // If the access url ends with '/*', remove the '*'.
+        if (accessUrl.indexOf('/*', accessUrl.length - 2) !== -1) {
+          accessUrl = accessUrl.substring(0, accessUrl.length - 1);
+        }
+        
+        if (accessUrl.indexOf(baseUrlPattern) !== 0) { // To avoid duplicates, add the rule only if it does not have the base URL as a prefix
+          applicationContentUriRules += indentationChars + '<uap:Rule Type="include" Match="' + accessUrl + '" />';
         }
       }
     }


### PR DESCRIPTION
When converting access rules from the W3C manifest to ACURs in Windows 10, we are now ignoring the wildcard character at the end of a an access rule. That way any URL that has an access content rule as a prefix will be opened inside the hosted web app.