### PR TITLE
Allow the start_url member of the W3C manifest to be optional. If uns…

### DIFF
--- a/lib/manifestTools.js
+++ b/lib/manifestTools.js
@@ -237,11 +237,15 @@ function validateAndNormalizeStartUrl(siteUrl, manifestInfo, callback) {
   if (manifestInfo.format !== c.BASE_MANIFEST_FORMAT) {
     return callback(new Error('The manifest found is not a W3C manifest.'), manifestInfo);
   }
-
+  
   var parsedSiteUrl = url.parse(siteUrl);
-  var parsedManifestStartUrl = url.parse(manifestInfo.content.start_url);
-  if (parsedManifestStartUrl.hostname && parsedSiteUrl.hostname !== parsedManifestStartUrl.hostname) {
-    return callback(new Error('The domain of the hosted site (' + parsedSiteUrl.hostname + ') does not match the domain of the manifest\'s start_url parameter (' + parsedManifestStartUrl.hostname + ')'), manifestInfo);
+  if (manifestInfo.content.start_url) {
+    var parsedManifestStartUrl = url.parse(manifestInfo.content.start_url);
+    if (parsedManifestStartUrl.hostname && parsedSiteUrl.hostname !== parsedManifestStartUrl.hostname) {
+      return callback(new Error('The domain of the hosted site (' + parsedSiteUrl.hostname + ') does not match the domain of the manifest\'s start_url parameter (' + parsedManifestStartUrl.hostname + ')'), manifestInfo);
+    }
+  } else {
+    manifestInfo.content.start_url = '/';
   }
 
   // make sure the manifest's start_url is an absolute URL


### PR DESCRIPTION
…pecified, the start_url is set to the target site's URL.