### PR TITLE
V0.3.1 cordova whitelist fix

### DIFF
--- a/lib/common/version.js
+++ b/lib/common/version.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var http = require('http'),
+    semver = require('semver'),
+    pkg = require('../../package.json');
+
+var getCurrentPackageVersion = function () {
+  return pkg.version;
+};
+
+var getCurrentPackageName = function () {
+  return pkg.name;
+};
+
+var getNpmPackageLatestVersion = function (packageName, callback) {
+  http.get('http://registry.npmjs.org/' + packageName + '/latest', function (res) {
+    var data = '';
+    
+    res.on('data', function (chunk) {
+      data += chunk;
+    });
+    
+    res.on('end', function () {
+      try {
+        var packageJson = JSON.parse(data);
+        callback(undefined, packageJson.version);
+      } catch (err) {
+        callback(err);
+      }
+    });
+  }).on('error', function (err) {
+    callback(err);
+  });
+};
+
+var checkForUpdate = function (callback) {
+  var name = getCurrentPackageName();
+  getNpmPackageLatestVersion(name, function (err, latestVersion) {
+    if (err) {
+      return callback && callback(err);
+    }
+
+    var currentVersion = getCurrentPackageVersion();
+    callback && callback(undefined, semver.lt(currentVersion, latestVersion) ? latestVersion : undefined);
+  });
+};
+
+module.exports = {
+  getCurrentPackageName : getCurrentPackageName,
+  getCurrentPackageVersion: getCurrentPackageVersion,
+  getNpmPackageLatestVersion: getNpmPackageLatestVersion,
+  checkForUpdate : checkForUpdate
+};

--- a/lib/projectBuilder.js
+++ b/lib/projectBuilder.js
@@ -507,6 +507,11 @@ var createCordovaApp = function (w3cManifestInfo, generatedAppDir, platforms, op
       if (options.crosswalk) {
         cmdLine += ' cordova-plugin-crosswalk-webview';
       }
+      
+      // Fixes an issue in Cordova that requires a version of cordova-ios that is not released yet 
+      // and stops automated plugin installations - see https://issues.apache.org/jira/browse/CB-9232
+      // and https://issues.apache.org/jira/browse/CB-916) - Needs to be removed once a fix is released!!!!
+      cmdLine += ' cordova-plugin-whitelist@1.0.0';
 
       log.debug('** ' + cmdLine);
       exec(cmdLine, function (err) {

--- a/manifoldjs.js
+++ b/manifoldjs.js
@@ -4,9 +4,20 @@ var validations = require('./lib/common/validations'),
     manifestTools = require('./lib/manifestTools'),
     projectBuilder = require('./lib/projectBuilder'),
     projectTools = require('./lib/projectTools'),
+    version = require('./lib/common/version'),
     url = require('url'),
     log = require('loglevel'),
     path = require('path');
+
+version.checkForUpdate(function (err, updateAvailable) {
+  if (!err && updateAvailable) {
+    console.log();
+    console.log('*****************************************************************************************');
+    console.log('*** A new version of ManifoldJS is available (v' + updateAvailable + '). We recommend that you upgrade. ***');
+    console.log('*****************************************************************************************');
+    console.log();
+  }
+});
 
 function checkParameters(argv) {
   if (argv._.length < 1) {


### PR DESCRIPTION
Includes temporary workaround for an issue caused by a recent update in Cordova’s whitelist plugin that requires a version of cordova-ios that is not released yet. Also, added a new "check for updates" feature to alert users when a new release of ManifoldJS is available.