### PR TITLE
V0.4.1 pietro exp1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.html
 *.njsproj
 *.suo
 *.sln
+.settings

--- a/lib/manifestTools.js
+++ b/lib/manifestTools.js
@@ -256,9 +256,15 @@ function validateAndNormalizeStartUrl(siteUrl, manifestInfo, callback) {
     var parsedSiteUrl = url.parse(siteUrl);
     var parsedManifestStartUrl = url.parse(manifestInfo.content.start_url);
     if (parsedManifestStartUrl.hostname && parsedSiteUrl.hostname !== parsedManifestStartUrl.hostname) {
-      // issue #88
-      var tmp_wwwParsedSiteName =  "www." + parsedSiteUrl.hostname;
-      if(tmp_wwwParsedSiteName.toLowerCase() !== parsedManifestStartUrl.hostname.toLowerCase()){
+       // issue #88 - bis
+      var subDomainOfManifestStartUrlSplitted = parsedManifestStartUrl.hostname.split('.');
+      var lengthSubDomain = subDomainOfManifestStartUrlSplitted.length;
+      var subDomainOfManifestStartUrl = null;
+      if(lengthSubDomain >= 2){
+        subDomainOfManifestStartUrl = 
+        subDomainOfManifestStartUrlSplitted[lengthSubDomain - 2] + "." + subDomainOfManifestStartUrlSplitted[lengthSubDomain - 1]
+      }
+      if(!subDomainOfManifestStartUrl || !utils.isURL(subDomainOfManifestStartUrl) || parsedSiteUrl.hostname.toLowerCase() !== subDomainOfManifestStartUrl.toLowerCase()){
         return callback(new Error('The domain of the hosted site (' + parsedSiteUrl.hostname + ') does not match the domain of the manifest\'s start_url member (' + parsedManifestStartUrl.hostname + ')'), manifestInfo);
       }
     }

--- a/lib/manifestTools.js
+++ b/lib/manifestTools.js
@@ -256,7 +256,11 @@ function validateAndNormalizeStartUrl(siteUrl, manifestInfo, callback) {
     var parsedSiteUrl = url.parse(siteUrl);
     var parsedManifestStartUrl = url.parse(manifestInfo.content.start_url);
     if (parsedManifestStartUrl.hostname && parsedSiteUrl.hostname !== parsedManifestStartUrl.hostname) {
-      return callback(new Error('The domain of the hosted site (' + parsedSiteUrl.hostname + ') does not match the domain of the manifest\'s start_url member (' + parsedManifestStartUrl.hostname + ')'), manifestInfo);
+      // issue #88
+      var tmp_wwwParsedSiteName =  "www." + parsedSiteUrl.hostname;
+      if(tmp_wwwParsedSiteName.toLowerCase() !== parsedManifestStartUrl.hostname.toLowerCase()){
+        return callback(new Error('The domain of the hosted site (' + parsedSiteUrl.hostname + ') does not match the domain of the manifest\'s start_url member (' + parsedManifestStartUrl.hostname + ')'), manifestInfo);
+      }
     }
     
     manifestInfo.content.start_url = url.resolve(siteUrl, manifestInfo.content.start_url);

--- a/test/assets/manifest_#88.json
+++ b/test/assets/manifest_#88.json
@@ -1,0 +1,74 @@
+{
+  "name": "This Here Web",
+  "short_name": "THW",
+  "icons": [
+    {
+      "src": "images/tiny.png",
+      "sizes": "70x70",
+      "type": "image/png"
+    },
+    {
+      "src": "images/wide.png",
+      "sizes": "310x150",
+      "type": "image/png"
+    },
+    {
+      "src": "images/large.png",
+      "sizes": "310x310",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square.png",
+      "sizes": "150x150",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-72x72.png",
+      "sizes": "72x72",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-57x57.png",
+      "sizes": "57x57",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-76x76.png",
+      "sizes": "76x76",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-60x60.png",
+      "sizes": "60x60",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-120x120.png",
+      "sizes": "120x120",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-152x152.png",
+      "sizes": "152x152",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-114x114.png",
+      "sizes": "114x114",
+      "type": "image/png"
+    },
+    {
+      "src": "imagessquare_Logo-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-128x128.png",
+      "sizes": "128x128",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "http://www.thishereweb.com/",
+  "display": "standalone",
+  "orientation": "landscape"
+}

--- a/test/assets/manifest_#88.json
+++ b/test/assets/manifest_#88.json
@@ -68,7 +68,7 @@
       "type": "image/png"
     }
   ],
-  "start_url": "http://www.thishereweb.com/",
+  "start_url": "http://www.test.thishereweb.com/a/",
   "display": "standalone",
   "orientation": "landscape"
 }

--- a/test/manifestTools.js
+++ b/test/manifestTools.js
@@ -25,7 +25,8 @@ var inputFiles = {
   notExistingFile: path.join(assetsDirectory, 'notExistingFile.json'),
   invalidManifest: path.join(assetsDirectory, 'invalid.json'),
   invalidManifestFormat: path.join(assetsDirectory, 'invalidManifestFormat.json'),
-  validManifest: path.join(assetsDirectory, 'manifest.json')
+  validManifest: path.join(assetsDirectory, 'manifest.json'),
+  issue88Manifest: path.join(assetsDirectory, 'manifest_#88.json')
 };
 
 var outputFiles = {
@@ -577,6 +578,19 @@ describe('Manifest Tools', function () {
 
       tools.validateManifest(manifestInfo, undefined, function(){
         done();
+      });
+    });
+    
+    it('Issue #88', function (done) {
+      
+      tools.getManifestFromFile(inputFiles.issue88Manifest, function (err, manifestObject){
+        var w3cmanifest = {
+          content: manifestObject,
+          format: "w3c"};
+        tools.validateAndNormalizeStartUrl ("http://thishereweb.com", w3cmanifest.content, function(err, results){
+          should.not.exist(err);
+        done();
+        });
       });
     });
 


### PR DESCRIPTION
- update to issue 88: now more subdomains string can be matched in the manifest start_url, like http:// sub1.domain.ext if the user passes domain.ext to manifoldjs cmd line.
- the test case for issue 88 has also been updated.