### PR TITLE
issue #145: don't require a short name

### DIFF
--- a/lib/manifestTools.js
+++ b/lib/manifestTools.js
@@ -117,6 +117,21 @@ function downloadManifestFromUrl(manifestUrl, callback) {
   });
 }
 
+function getDefaultShortName(siteUrl) {
+    var shortName = '';
+    url.parse(siteUrl)
+        .hostname
+        .split('.')
+        .map(function (segment) {
+              segment.split('-')
+                      .map(function (fraction) {
+                            shortName = shortName + utils.capitalize(fraction);
+                      });
+        });
+
+    return shortName;
+}
+
 function getManifestFromSite(siteUrl, callback) {
   fetchManifestUrlFromSite(siteUrl, function (err, manifestUrl) {
     if (err) {
@@ -129,16 +144,7 @@ function getManifestFromSite(siteUrl, callback) {
       // TODO: review what to do in this case. (manifest meta tag is not present)
       log.warn('WARNING: No manifest found. A new manifest will be created.');
 
-      var shortName = '';
-      url.parse(siteUrl)
-         .hostname
-         .split('.')
-         .map(function (segment) {
-                segment.split('-')
-                       .map(function (fraction) {
-                              shortName = shortName + utils.capitalize(fraction);
-                        });
-          });
+      var shortName = getDefaultShortName(siteUrl);
 
       return callback(null, {
         content: {
@@ -260,6 +266,8 @@ function validateAndNormalizeStartUrl(siteUrl, manifestInfo, callback) {
     }
     
     manifestInfo.content.start_url = url.resolve(siteUrl, manifestInfo.content.start_url);
+    
+    manifestInfo.default = { short_name: getDefaultShortName(siteUrl) };
   }
 
   return callback(undefined, manifestInfo);

--- a/manifoldjs.js
+++ b/manifoldjs.js
@@ -208,6 +208,11 @@ if (program.run) {
       return;
     }
 
+      // Fix #145: don't require a short name
+    manifestInfo.content.short_name =   manifestInfo.content.short_name || 
+                                        manifestInfo.content.name ||
+                                        manifestInfo.default.short_name;
+
     // if specified as a parameter, override the app's short name
     if (program.shortname) {
       manifestInfo.content.short_name = program.shortname;


### PR DESCRIPTION
Defined a default value for short_name after validating the start URL. This value can be used when either name or short_name is not provided in the manifest file.
- encapsulated the original code for generating default value inside getDefaultShortName()
- added a property named "default.short_name" to "manifestInfo"
- added a logic to pickup a default value when either name and short_name are not provided