### PR TITLE
allow for density to be strings not numbers #144

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.html
 *.njsproj
 *.suo
 *.sln
+.settings

--- a/lib/manifestTools.js
+++ b/lib/manifestTools.js
@@ -117,6 +117,21 @@ function downloadManifestFromUrl(manifestUrl, callback) {
   });
 }
 
+function getDefaultShortName(siteUrl) {
+    var shortName = '';
+    url.parse(siteUrl)
+        .hostname
+        .split('.')
+        .map(function (segment) {
+              segment.split('-')
+                      .map(function (fraction) {
+                            shortName = shortName + utils.capitalize(fraction);
+                      });
+        });
+
+    return shortName;
+}
+
 function getManifestFromSite(siteUrl, callback) {
   fetchManifestUrlFromSite(siteUrl, function (err, manifestUrl) {
     if (err) {
@@ -129,16 +144,7 @@ function getManifestFromSite(siteUrl, callback) {
       // TODO: review what to do in this case. (manifest meta tag is not present)
       log.warn('WARNING: No manifest found. A new manifest will be created.');
 
-      var shortName = '';
-      url.parse(siteUrl)
-         .hostname
-         .split('.')
-         .map(function (segment) {
-                segment.split('-')
-                       .map(function (fraction) {
-                              shortName = shortName + utils.capitalize(fraction);
-                        });
-          });
+      var shortName = getDefaultShortName(siteUrl);
 
       return callback(null, {
         content: {
@@ -270,6 +276,8 @@ function validateAndNormalizeStartUrl(siteUrl, manifestInfo, callback) {
     }
     
     manifestInfo.content.start_url = url.resolve(siteUrl, manifestInfo.content.start_url);
+    
+    manifestInfo.default = { short_name: getDefaultShortName(siteUrl) };
   }
 
   return callback(undefined, manifestInfo);

--- a/lib/manifestTools.js
+++ b/lib/manifestTools.js
@@ -256,7 +256,17 @@ function validateAndNormalizeStartUrl(siteUrl, manifestInfo, callback) {
     var parsedSiteUrl = url.parse(siteUrl);
     var parsedManifestStartUrl = url.parse(manifestInfo.content.start_url);
     if (parsedManifestStartUrl.hostname && parsedSiteUrl.hostname !== parsedManifestStartUrl.hostname) {
-      return callback(new Error('The domain of the hosted site (' + parsedSiteUrl.hostname + ') does not match the domain of the manifest\'s start_url member (' + parsedManifestStartUrl.hostname + ')'), manifestInfo);
+       // issue #88 - bis
+      var subDomainOfManifestStartUrlSplitted = parsedManifestStartUrl.hostname.split('.');
+      var lengthSubDomain = subDomainOfManifestStartUrlSplitted.length;
+      var subDomainOfManifestStartUrl = null;
+      if(lengthSubDomain >= 2){
+        subDomainOfManifestStartUrl = 
+        subDomainOfManifestStartUrlSplitted[lengthSubDomain - 2] + "." + subDomainOfManifestStartUrlSplitted[lengthSubDomain - 1]
+      }
+      if(!subDomainOfManifestStartUrl || !utils.isURL(subDomainOfManifestStartUrl) || parsedSiteUrl.hostname.toLowerCase() !== subDomainOfManifestStartUrl.toLowerCase()){
+        return callback(new Error('The domain of the hosted site (' + parsedSiteUrl.hostname + ') does not match the domain of the manifest\'s start_url member (' + parsedManifestStartUrl.hostname + ')'), manifestInfo);
+      }
     }
     
     manifestInfo.content.start_url = url.resolve(siteUrl, manifestInfo.content.start_url);

--- a/lib/manifestTools/assets/web-manifest.json
+++ b/lib/manifestTools/assets/web-manifest.json
@@ -46,8 +46,8 @@
       "properties": {
         "density": {
           "description": "The density member of an icon is the device pixel density for which this icon was designed.",
-          "type": "number",
-          "default": 1.0
+          "type": [ "number", "string" ],
+          "default": [ 1.0, "one" ]
         },
         "sizes": {
           "description": "The sizes member is a string consisting of an unordered set of unique space-separated tokens which are ASCII case-insensitive that represents the dimensions of an icon for visual media.",

--- a/lib/projectTools.js
+++ b/lib/projectTools.js
@@ -3,26 +3,15 @@
     fs = require('fs'),
     path = require('path'),
     exec = require('child_process').exec,
-    log = require('loglevel');
+    log = require('loglevel'),
+    hwa = require('hwa');
 
 var originalPath = process.cwd();
 
 var installWindows10App = function (manifestPath, callback) {
   log.info('Installing Windows 10 app...');
-  var cmdLine = 'powershell Add-AppxPackage -Register ' + manifestPath;
-  log.debug('    ' + cmdLine);
-  exec(cmdLine, function (err, stdout, stderr) {
-    log.debug(stdout);
-    if (err) {
-      log.debug(err);
-      return callback(new Error('Failed to install the Windows 10 app.'));
-    } else if (stderr.length) {
-      log.error(stderr.trim());
-    }
-
-    log.warn('The app was installed. You can now launch the app from your recently installed apps list in Start menu');
-    callback();
-  });
+  hwa.registerApp(manifestPath);
+  callback();
 };
 
 var isWindows10Version = function (version) {

--- a/manifoldjs.js
+++ b/manifoldjs.js
@@ -208,6 +208,11 @@ if (program.run) {
       return;
     }
 
+      // Fix #145: don't require a short name
+    manifestInfo.content.short_name =   manifestInfo.content.short_name || 
+                                        manifestInfo.content.name ||
+                                        manifestInfo.default.short_name;
+
     // if specified as a parameter, override the app's short name
     if (program.shortname) {
       manifestInfo.content.short_name = program.shortname;

--- a/package.json
+++ b/package.json
@@ -35,9 +35,10 @@
   "dependencies": {
     "archiver": "^0.14.4",
     "cheerio": "^0.18.0",
+    "cloudappx-server": "^0.0.4",
     "commander": "^2.8.1",
     "cordova": "5.1.1",
-    "cloudappx-server": "^0.0.4",
+    "hwa": "^0.0.4",
     "loglevel": "^1.2.0",
     "mkdirp": "^0.5.0",
     "ncp": "^2.0.0",

--- a/test/assets/manifest_#88.json
+++ b/test/assets/manifest_#88.json
@@ -1,0 +1,74 @@
+{
+  "name": "This Here Web",
+  "short_name": "THW",
+  "icons": [
+    {
+      "src": "images/tiny.png",
+      "sizes": "70x70",
+      "type": "image/png"
+    },
+    {
+      "src": "images/wide.png",
+      "sizes": "310x150",
+      "type": "image/png"
+    },
+    {
+      "src": "images/large.png",
+      "sizes": "310x310",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square.png",
+      "sizes": "150x150",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-72x72.png",
+      "sizes": "72x72",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-57x57.png",
+      "sizes": "57x57",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-76x76.png",
+      "sizes": "76x76",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-60x60.png",
+      "sizes": "60x60",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-120x120.png",
+      "sizes": "120x120",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-152x152.png",
+      "sizes": "152x152",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-114x114.png",
+      "sizes": "114x114",
+      "type": "image/png"
+    },
+    {
+      "src": "imagessquare_Logo-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "images/square_Logo-128x128.png",
+      "sizes": "128x128",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "http://www.test.thishereweb.com/a/",
+  "display": "standalone",
+  "orientation": "landscape"
+}

--- a/test/manifestTools.js
+++ b/test/manifestTools.js
@@ -25,7 +25,8 @@ var inputFiles = {
   notExistingFile: path.join(assetsDirectory, 'notExistingFile.json'),
   invalidManifest: path.join(assetsDirectory, 'invalid.json'),
   invalidManifestFormat: path.join(assetsDirectory, 'invalidManifestFormat.json'),
-  validManifest: path.join(assetsDirectory, 'manifest.json')
+  validManifest: path.join(assetsDirectory, 'manifest.json'),
+  issue88Manifest: path.join(assetsDirectory, 'manifest_#88.json')
 };
 
 var outputFiles = {
@@ -577,6 +578,19 @@ describe('Manifest Tools', function () {
 
       tools.validateManifest(manifestInfo, undefined, function(){
         done();
+      });
+    });
+    
+    it('Issue #88', function (done) {
+      
+      tools.getManifestFromFile(inputFiles.issue88Manifest, function (err, manifestObject){
+        var w3cmanifest = {
+          content: manifestObject,
+          format: "w3c"};
+        tools.validateAndNormalizeStartUrl ("http://thishereweb.com", w3cmanifest.content, function(err, results){
+          should.not.exist(err);
+        done();
+        });
       });
     });
 


### PR DESCRIPTION
Was previously just accepting numbers, not accepts string, too.

  "definitions": {
    "icon": {
      "type": "object",
      "properties": {
        "density": {
          "description": "The density member of an icon is the device pixel density for which this icon was designed.",
          "type": [ "number", "string" ],
          "default": [ 1.0, "one" ]
        },