### PR TITLE
density now accepts type string for manifest for web manifest

### DIFF
--- a/lib/manifestTools/assets/web-manifest.json
+++ b/lib/manifestTools/assets/web-manifest.json
@@ -46,8 +46,8 @@
       "properties": {
         "density": {
           "description": "The density member of an icon is the device pixel density for which this icon was designed.",
-          "type": "number",
-          "default": 1.0
+          "type": [ "number", "string" ],
+          "default": [ 1.0, "one" ]
         },
         "sizes": {
           "description": "The sizes member is a string consisting of an unordered set of unique space-separated tokens which are ASCII case-insensitive that represents the dimensions of an icon for visual media.",

--- a/lib/manifestTools/assets/web-manifest.json
+++ b/lib/manifestTools/assets/web-manifest.json
@@ -47,7 +47,7 @@
         "density": {
           "description": "The density member of an icon is the device pixel density for which this icon was designed.",
           "type": [ "number", "string" ],
-          "default": [ 1.0, "one" ]
+          "default": [ 1.0, "1.0" ]
         },
         "sizes": {
           "description": "The sizes member is a string consisting of an unordered set of unique space-separated tokens which are ASCII case-insensitive that represents the dimensions of an icon for visual media.",

--- a/lib/manifestTools/assets/web-manifest.json
+++ b/lib/manifestTools/assets/web-manifest.json
@@ -47,7 +47,7 @@
         "density": {
           "description": "The density member of an icon is the device pixel density for which this icon was designed.",
           "type": [ "number", "string" ],
-          "default": [ 1.0, "1.0" ]
+          "default":  [ 1.0, "1.0" ]
         },
         "sizes": {
           "description": "The sizes member is a string consisting of an unordered set of unique space-separated tokens which are ASCII case-insensitive that represents the dimensions of an icon for visual media.",


### PR DESCRIPTION
density now accepts type string for manifest for web manifest

  "definitions": {
    "icon": {
      "type": "object",
      "properties": {
        "density": {
          "description": "The density member of an icon is the device pixel density for which this icon was designed.",
          "type": [ "number", "string" ],
          "default":  [ 1.0, "1.0" ]
        },