### PR TITLE
V0.6.0 Updates to windows10 platform, core library. Adds support for packaging Edge extensions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ manifoldjs <command>
 | `-p, --platforms` | **(optional)** Platforms to generate. Supported platforms: _windows,windows10,android,ios,chrome,web,firefox_ (default value: all platforms) |
 | `-b, --build`     | **(optional)** Forces the building process |
 | `-m, --manifest`  | **(optional)** Location of the W3C Web App manifest file (URL or local path). If not specified, the tool looks for a manifest in the site URL. Otherwise, a new manifest will be created pointing to the site URL. |
+| `-f, --forceManifestFormat`  | **(optional)** Allows to specify the manifest format and skip the automatic detection. Can be used when the manifest contains additional, non-standard members. |
 | `-c, --crosswalk` | **(optional)** Enable Crosswalk for Android. Crosswalk is a web runtime that can be used to replace the stock WebView used by Android Cordova apps. Crosswalk is based on Google Chromium with Cordova API support and has better HTML5 feature support compared to the default WebView available in Android. |
 | `-w, --webAppToolkit` | **(optional)** Adds the [Web App Toolkit](https://github.com/manifoldjs/Web-App-ToolKit) cordova plugin. The Web App Toolkit is a plugin for creating Windows, Android and iOS apps based on existing web content. It depends on the Hosted Web App Plugin. Used in the right way, it can facilitate the creation of compelling extensions to your web content for users across platforms. |
 
@@ -44,8 +45,8 @@ manifoldjs <command>
 
 |  **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Command&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;** | **Description** |
 | ---------------- | --------------- |
-| `run <platform>` | Launches the app of the specified platform. Currently, only _android_ and _windows_ platforms are supported by this command |
-| `visualstudio`   | (for Windows only) Opens the project file of the generated Windows 8.1 / Windows 10 app in Visual Studio |
+| `run <platform>` | Launches the app of the specified platform. Currently, _android_, _ios_, _windows_ and _windows10_ platforms are supported by this command |
+| `open`   | (for Windows only) Opens the project file of the generated Windows 8.1 / Windows 10 app in Visual Studio |
 | `package <platform (-p)-optional> <platform-list-optional>`   | Creates a package for supported platforms (windows10, android, iOS)  for uploading to the Store, where _&lt;platform (-p)&gt;_ is an optional parameter to specificy the platform to be packaged. The  _&lt;platform-list&gt;_ is used in conjunction with the platform.  In some cases, like Windows 10, data must be pulled from the store and updated in the manifest before it can be uploaded.|
 
 ### Example

--- a/commands/generate.js
+++ b/commands/generate.js
@@ -14,7 +14,7 @@ var log = lib.log,
 
 var build = require('./package');
 
-function getW3cManifest(siteUrl, manifestLocation, callback) {
+function getW3cManifest(siteUrl, manifestLocation, manifestFormat, callback) {
   function resolveStartURL(err, manifestInfo) {
     if (err) {
       return callback(err, manifestInfo);
@@ -35,16 +35,16 @@ function getW3cManifest(siteUrl, manifestLocation, callback) {
     if (parsedManifestUrl && parsedManifestUrl.host) {
       // download manifest from remote location
       log.info('Downloading manifest from ' + manifestLocation + '...');
-      manifestTools.downloadManifestFromUrl(manifestLocation, resolveStartURL);
+      manifestTools.downloadManifestFromUrl(manifestLocation, manifestFormat, resolveStartURL);
     } else {
       // read local manifest file
       log.info('Reading manifest file ' + manifestLocation + '...');
-      manifestTools.getManifestFromFile(manifestLocation, resolveStartURL);
+      manifestTools.getManifestFromFile(manifestLocation, manifestFormat, resolveStartURL);
     }
   } else if (siteUrl) {    
     // scan a site to retrieve its manifest
     log.info('Scanning ' + siteUrl + ' for manifest...');
-    manifestTools.getManifestFromSite(siteUrl, resolveStartURL);
+    manifestTools.getManifestFromSite(siteUrl, manifestFormat, resolveStartURL);
   } else {
     return callback(new Error('A site URL or manifest should be specified.'));
   }
@@ -101,14 +101,14 @@ function generateApp(program) {
   if (platforms.length === 1 && platforms[0] === 'edgeextension')
   {
     if (program.manifest) {
-      manifestTools.getManifestFromFile(program.manifest, callback);
+      manifestTools.getManifestFromFile(program.manifest, program.forceManifestFormat, callback);
     } else {
       return callback(new Error('A local manifest file should be specified.'));
     }
     return deferred.promise;
   }
   
-  getW3cManifest(siteUrl, program.manifest, callback);
+  getW3cManifest(siteUrl, program.manifest, program.forceManifestFormat, callback);
   
   return deferred.promise;
 };

--- a/commands/generate.js
+++ b/commands/generate.js
@@ -9,6 +9,7 @@ var lib = require('manifoldjs-lib');
 
 var log = lib.log,
     manifestTools = lib.manifestTools,
+    platformTools = lib.platformTools,
     projectBuilder = lib.projectBuilder,
     utils = lib.utils;
 
@@ -20,7 +21,11 @@ function getW3cManifest(siteUrl, manifestLocation, manifestFormat, callback) {
       return callback(err, manifestInfo);
     }
 
-    return manifestTools.validateAndNormalizeStartUrl(siteUrl, manifestInfo, callback);
+    if (manifestInfo.format === lib.constants.BASE_MANIFEST_FORMAT) {
+      return manifestTools.validateAndNormalizeStartUrl(siteUrl, manifestInfo, callback);
+    } else {
+      return callback(undefined, manifestInfo);
+    }
   }
   
   if (siteUrl) {
@@ -54,7 +59,6 @@ function generateApp(program) {
   
   var siteUrl = program.args[0];
   var rootDir = program.directory ? path.resolve(program.directory) : process.cwd();
-  var platforms = program.platforms.split(/[\s,]+/);
   
   var deferred = Q.defer();
   
@@ -78,11 +82,26 @@ function generateApp(program) {
     // add generatedFrom value to manifestInfo for telemetry
     manifestInfo.generatedFrom = 'CLI';
 
+    var platforms = [];
+    if (program.platforms) {
+      platforms = program.platforms.split(/[\s,]+/);
+    } else {
+      platforms = platformTools.listPlatforms();
+      // Remove edgeextension from the default platforms for W3C manifests
+      if (manifestInfo.format === lib.constants.BASE_MANIFEST_FORMAT) {
+        var edgeIndex = platforms.indexOf('edgeextension');
+        if (edgeIndex > -1) {
+          log.debug('Removing Edge Extension platform. The W3C manifest format is not currently supported by this platform.');
+          platforms.splice(edgeIndex, 1);
+        }
+      }
+    }
+
     // Create the apps for the specified platforms
     return projectBuilder.createApps(manifestInfo, rootDir, platforms, program).then(function (projectDir) {
       if (program.build) {
         program.args[1] = projectDir;
-        return build(program).catch(function (err) {
+        return build(program, platforms).catch(function (err) {
           log.warn('One or more platforms could not be built successfully. Correct any errors and then run manifoldjs package [project-directory] [options] to build the applications.');
           // return deferred.reject(err);
         });
@@ -95,18 +114,7 @@ function generateApp(program) {
     .catch(function (err) {
       return deferred.reject(err);
     });
-  };  
-  
-  
-  if (platforms.length === 1 && platforms[0] === 'edgeextension')
-  {
-    if (program.manifest) {
-      manifestTools.getManifestFromFile(program.manifest, program.forceManifestFormat, callback);
-    } else {
-      return callback(new Error('A local manifest file should be specified.'));
-    }
-    return deferred.promise;
-  }
+  };
   
   getW3cManifest(siteUrl, program.manifest, program.forceManifestFormat, callback);
   

--- a/commands/package.js
+++ b/commands/package.js
@@ -3,11 +3,16 @@
 var lib = require('manifoldjs-lib');
 
 var log = lib.log,
+    platformTools= lib.platformTools,
     projectBuilder = lib.projectBuilder;
 
-function packageApps(program) {
-  
-  var platforms = program.platforms.split(/[\s,]+/);  
+function packageApps(program, platforms) {
+  if (!platforms) {
+    platforms = program.platforms ? 
+                program.platforms.split(/[\s,]+/) :
+                platformTools.listPlatforms();
+  }
+
   var projectDir = program.args.length < 2 ? process.cwd() : program.args[1];
   return lib.projectTools.getProjectPlatforms(projectDir).then(function (projectPlatforms) {
     // exclude any platforms not present in the project

--- a/manifoldjs.js
+++ b/manifoldjs.js
@@ -131,7 +131,7 @@ var program = require('commander')
              .option('-d, --directory <app-dir>', 'path to the generated project files')
              .option('-s, --shortname <short-name>', 'application short name')
              .option('-l, --loglevel <log-level>', 'debug|info|warn|error', 'warn')
-             .option('-p, --platforms <platforms>', getPlatformHelpText(), availablePlatforms.join(',')) 
+             .option('-p, --platforms <platforms>', getPlatformHelpText()) 
              .option('-b, --build', 'forces the building process', false)
              .option('-m, --manifest <manifest-location>', 'location of the W3C Web App manifest\n                                    ' +
                                                     'file (URL or local path)')

--- a/manifoldjs.js
+++ b/manifoldjs.js
@@ -8,9 +8,13 @@ var lib = require('manifoldjs-lib');
 var log = lib.log,
     packageTools = lib.packageTools,
     platformTools = lib.platformTools,
+    manifestTools = lib.manifestTools,
     validations = lib.validations; 
 
 var commands = require('./commands');
+
+// Get the available formats for the --forceManifestFormat parameter
+var availableManifestFormats = manifestTools.listAvailableManifestFormats();
 
 function checkParameters(program) {
   var unknownArgs = 0;
@@ -66,6 +70,12 @@ function checkParameters(program) {
       return 'Invalid loglevel specified. Valid values are: debug, info, warn, error.';
     }
   }
+
+  if (program.forceManifestFormat) {
+    if (!validations.manifestFormatValid(program.forceManifestFormat)) {
+      return 'Invalid manifest format specified. Valid values are: ' + availableManifestFormats.join(', ') + '.';
+    }
+  }
 }
 
 // get the list of registered platforms
@@ -96,7 +106,7 @@ var program = require('commander')
                     '\n         manifoldjs -m <manifest-location> [options]' +
                     '\n           options:' +
                     '\n             -d | --directory, -s | --short-name, -l | --loglevel,' +
-                    '\n             -p | --platforms, -m | --manifest,   -c | --crosswalk' +                    
+                    '\n             -p | --platforms, -m | --manifest, -f | --forceManifestFormat, -c | --crosswalk' +                    
                     '\n  -or-' +
                     '\n         manifoldjs package [project-directory] [options]' +
                     '\n           options:' +
@@ -128,6 +138,7 @@ var program = require('commander')
              .option('-c, --crosswalk', 'enable Crosswalk for Android', false)
              .option('-S, --Sign', 'return a signed package in windows', false)
              .option('-w, --webAppToolkit', 'adds the Web App Toolkit cordova plugin', false)
+             .option('-f, --forceManifestFormat <format>', availableManifestFormats.join('|'))
              .parse(process.argv);
 
 if (!process.argv.slice(2).length) {

--- a/manifoldjs.js
+++ b/manifoldjs.js
@@ -139,6 +139,7 @@ var program = require('commander')
              .option('-S, --Sign', 'return a signed package in windows', false)
              .option('-w, --webAppToolkit', 'adds the Web App Toolkit cordova plugin', false)
              .option('-f, --forceManifestFormat <format>', availableManifestFormats.join('|'))
+             .option('-W, --DotWeb', 'generate a .web package in windows', false)
              .parse(process.argv);
 
 if (!process.argv.slice(2).length) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manifoldjs",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Node.js Tool for App Generation",
   "repository": {
     "type": "git",
@@ -35,13 +35,13 @@
   "dependencies": {
     "commander": "^2.9.0",
     "q": "^1.4.1",
-    "manifoldjs-lib": "^0.1.2",
-    "manifoldjs-chrome": "^0.1.2",
-    "manifoldjs-cordova": "^0.1.2",
-    "manifoldjs-firefox": "^0.1.2",
-    "manifoldjs-web": "^0.1.2",
-    "manifoldjs-windows10": "^0.1.2",
-    "manifoldjs-edgeextension": "https://github.com/manifoldjs/manifoldjs-edgeextension.git"
+    "manifoldjs-lib": "^1.0.0",
+    "manifoldjs-chrome": "^0.1.3",
+    "manifoldjs-cordova": "^0.1.3",
+    "manifoldjs-firefox": "^0.1.3",
+    "manifoldjs-web": "^0.1.3",
+    "manifoldjs-windows10": "^0.1.3",
+    "manifoldjs-edgeextension": "^0.1.3"
   },
   "devDependencies": {
     "blanket": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "manifoldjs-cordova": "^0.1.2",
     "manifoldjs-firefox": "^0.1.2",
     "manifoldjs-web": "^0.1.2",
-    "manifoldjs-windows10": "^0.1.2"
+    "manifoldjs-windows10": "^0.1.2",
+    "manifoldjs-edgeextension": "https://github.com/manifoldjs/manifoldjs-edgeextension.git"
   },
   "devDependencies": {
     "blanket": "1.1.6",

--- a/platforms.json
+++ b/platforms.json
@@ -26,5 +26,9 @@
     "web": {
         "packageName": "manifoldjs-web",
         "source": "manifoldjs-web"
+    },
+    "edgeextension": {
+        "packageName": "manifoldjs-edgeextension",
+        "source": "https://github.com/manifoldjs/manifoldjs-edgeextension.git"
     }
 }

--- a/platforms.json
+++ b/platforms.json
@@ -29,6 +29,6 @@
     },
     "edgeextension": {
         "packageName": "manifoldjs-edgeextension",
-        "source": "https://github.com/manifoldjs/manifoldjs-edgeextension.git"
+        "source": "manifoldjs-edgeextension"
     }
 }


### PR DESCRIPTION
This release contains mainly updates to the manifoldjs-windows10 platform and the manifoldjs-lib core library. It also adds initial support to generate and package Edge Extension apps.

#### Enhancements
- Update manifoldjs-lib version to 1.0.0
- Added -f option to be specific about the manifest format and skip the detection (issue manifoldjs/manifoldjs-lib#21)
- [Win10] Support for additional image sizes: scale-200, scale-125, scale-150 and scale-400 (issue manifoldjs/manifoldjs-windows10#10)
- [Win10] Added support to specify capabilities in the w3c manifest through the `mjs_capabilities` member (issue manifoldjs/manifoldjs-windows10#9)
- Edge Extensions support: Edge Extensions can now be generated and packaged through the `edgeextension` platform, using an Edge Extension manifest JSON as input. More details [here](https://github.com/manifoldjs/manifoldjs-edgeextension).

#### Bug Fixes
- Added missing members for W3C manifest validation: description, background_color, dir (issue manifoldjs/manifoldjs-lib#12)
- Only run the "All Platform" validations for W3C manifests (issue manifoldjs/manifoldjs-lib#20)